### PR TITLE
May be smarter to to use OnPlayerClicks

### DIFF
--- a/src/main/java/io/github/_7isenko/dreamcompass/CompassInteractListener.java
+++ b/src/main/java/io/github/_7isenko/dreamcompass/CompassInteractListener.java
@@ -14,7 +14,7 @@ import org.bukkit.inventory.ItemStack;
 public class CompassInteractListener implements Listener {
     @EventHandler(ignoreCancelled = true)
     @SuppressWarnings({"ConstantConditions", "unused"})
-    public void onEvent(PlayerInteractEvent e) {
+    public void onPlayerClicks(PlayerInteractEvent e) {
         Player player = e.getPlayer();
         ItemStack compass = getCompass(player);
         if (compass == null) return;


### PR DESCRIPTION
This change will allow the user to just always use the compass without the need of clicking a block. (OnEvent isn't called in my testing of 1.16.1 when clicking air)